### PR TITLE
Use Go 1.18 as minimal version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/RealAlexandreAI/json-repair
 
-go 1.1
+go 1.18


### PR DESCRIPTION
This version is widely spread and accepted

Fixes #2
