### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/RealAlexandreAI/json-repair/security/code-scanning/1](https://github.com/RealAlexandreAI/json-repair/security/code-scanning/1)

In general, the fix is to explicitly declare `permissions` for the `GITHUB_TOKEN` at the workflow or job level and restrict them to the minimum required. This job only checks out code and runs tests; it doesn’t appear to need any write access to repository contents, issues, or pull requests. Therefore, `contents: read` at the job (or workflow) level is an appropriate minimal setting.

The single best fix without changing existing functionality is to add a `permissions:` block scoped to the `build` job under `.github/workflows/ci.yaml`. This avoids changing behavior for any other jobs that might exist in the file (none are shown, but we stay local to what we see) and documents the required access. Concretely, in `.github/workflows/ci.yaml`, directly under the `runs-on: ubuntu-latest` line for the `build` job, add:

```yaml
    permissions:
      contents: read
```

No additional methods, imports, or definitions are required; this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
